### PR TITLE
Fix 'view sample codeblock' issue

### DIFF
--- a/templates/_configs.njk
+++ b/templates/_configs.njk
@@ -8,8 +8,8 @@
         <div class="mb-config-options">
             <div class="superfences-tabs">
             {% set tabid = tabid + 1 %}
-            <input name="{{tabid}}" type="checkbox" id="{{tabid}}">
-                <label class="tab-selector" for="{{tabid}}"><i class="icon fa fa-code"></i></label>
+            <input name="{{tabid}}" type="checkbox" id="_tab_{{tabid}}">
+                <label class="tab-selector" for="_tab_{{tabid}}"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">{% include "../data/" + config.exampleFile %}</code></pre>

--- a/templates/_configs.njk
+++ b/templates/_configs.njk
@@ -1,3 +1,4 @@
+{% set tabid = 1 %}
 {% for config in configs %}
 
 ## {{ config.title | safe }}
@@ -6,8 +7,9 @@
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            <input name="__tabs_1" type="checkbox" id="__tab_1_0">
-                <label class="tab-selector" for="__tab_1_0"><i class="icon fa fa-code"></i></label>
+            {% set tabid = tabid + 1 %}
+            <input name="{{tabid}}" type="checkbox" id="{{tabid}}">
+                <label class="tab-selector" for="{{tabid}}"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">{% include "../data/" + config.exampleFile %}</code></pre>


### PR DESCRIPTION
Issue - The first sample code block in the config catalog appears as expected, however the second code block onwards does not appear. This is because the tabID does not get incremented properly.

This PR fixes this issue by incrementing the tabID using a 'tabid' variable. 